### PR TITLE
Fix: 일반 타입 String 사용하지 않기

### DIFF
--- a/src/styles/style.d.ts
+++ b/src/styles/style.d.ts
@@ -3,15 +3,15 @@ import 'styled-components';
 declare module 'styled-components'{
     export interface DefaultTheme {
         palette:{
-            triconblack: String,
-            africanviolet: String,
-            daydream: String,
-            lobelia: String,
-            extrawhite: String,
+            triconblack: string,
+            africanviolet: string,
+            daydream: string,
+            lobelia: string,
+            extrawhite: string,
         }
         devices: {
-            desktop: String,
-            mobile: String
+            desktop: string,
+            mobile: string
         }
     }
 }


### PR DESCRIPTION
fix #6 - 일반 타입인 String 대신 string으로 수정했습니다.

아래 스크린샷과 같이 theme 사용 시 오류가 사라졌습니다.

![image](https://user-images.githubusercontent.com/27720475/173586512-52dad30c-9b75-4a31-b34c-8f2092692bae.png)
