### PR TITLE
Feat: 태그 하이라이팅 고도화

### DIFF
--- a/src/components/gallery/TagList.tsx
+++ b/src/components/gallery/TagList.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 const StyledTagList = styled.div`
@@ -32,62 +32,48 @@ const Tag = styled.li`
   line-height: 1.5;
   color: ${(props) => props.theme.palette.triconblack};
   font-weight: bold;
+  cursor: pointer;
 
-  & span {
-      margin-left: 0.5rem;
-      color: ${(props) => props.theme.palette.daydream};
-      font-weight: normal;
-  };
-`;
-
-const StyledLink = styled(Link)`
-  text-decoration: none;
-  color: inherit;
-
-  :hover {
-    text-decoration: underline;
-  };
-  
-  &.selected {
+  &.selected span {
     color: ${(props) => props.theme.palette.lobelia};
     font-weight: bold;
   }
 `;
 
-function TagList({ postCount, tags }) {
-  const [selectedId, setSelectedId] = useState('');
+const StyledSpan = styled.span`
+  margin-left: 0.5rem;
+  color: ${(props) => props.theme.palette.daydream};
+  font-weight: normal;
+
+  :hover {
+    text-decoration: underline;
+  };
+`;
+
+function TagList({ tags }) {
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const handleClick = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
 
-    if (e.target.nodeName === 'A') {
-      setSelectedId(e.target.id);
+    const target = e.target.closest('li');
+    const id = target.dataset.id.split('taglist-')[1];
+    if (id === 'all') {
+      searchParams.delete('tag');
+    } else if (id) {
+      searchParams.set('tag', id);
     }
+    setSearchParams(searchParams);
   };
 
-  // TODO
-  // - [ ] 전체보기 카테고리 생기면 수정
   return (
     <StyledTagList className="TagList" onClick={handleClick}>
       <div>
         <div className="title">태그 목록</div>
         <ul>
-          <Tag key="allCategories">
-            <StyledLink to="/gallery" id="allCategories" className="Tag selected">전체보기</StyledLink>
-            <span>
-              (
-              {postCount}
-              )
-            </span>
-          </Tag>
           {tags.map(({ _id, name, post }) => (
-            <Tag key={_id} className="Tag">
-              <StyledLink to={`/gallery?tag=${_id}`} id={_id} className={`${_id === selectedId ? 'selected' : null}`}>{name}</StyledLink>
-              <span>
-                (
-                {post}
-                )
-              </span>
+            <Tag key={_id} data-id={`taglist-${_id}`} className={_id === searchParams.get('tag') ? 'selected' : undefined}>
+              <StyledSpan>{`${name}(${post})`}</StyledSpan>
             </Tag>
           ))}
         </ul>

--- a/src/components/gallery/TagList.tsx
+++ b/src/components/gallery/TagList.tsx
@@ -71,8 +71,10 @@ function TagList({ tags }) {
       <div>
         <div className="title">태그 목록</div>
         <ul>
-          {tags.map(({ _id, name, post }) => (
-            <Tag key={_id} data-id={`taglist-${_id}`} className={_id === searchParams.get('tag') ? 'selected' : undefined}>
+          {tags.map(({
+            _id, name, post, selected,
+          }) => (
+            <Tag key={_id} data-id={`taglist-${_id}`} className={selected ? 'selected' : undefined}>
               <StyledSpan>{`${name}(${post})`}</StyledSpan>
             </Tag>
           ))}

--- a/src/components/gallery/Tags.tsx
+++ b/src/components/gallery/Tags.tsx
@@ -57,8 +57,10 @@ function Tags({ tags }) {
 
   return (
     <StyledTags className="Tags" onClick={handleClick}>
-      {tags.map(({ _id, name, post }) => (
-        <Tag key={_id} data-id={`tags-${_id}`} className={_id === searchParams.get('tag') ? 'selected' : undefined}>
+      {tags.map(({
+        _id, name, post, selected,
+      }) => (
+        <Tag key={_id} data-id={`tags-${_id}`} className={selected ? 'selected' : undefined}>
           {`${name}(${post})`}
         </Tag>
       ))}

--- a/src/components/gallery/Tags.tsx
+++ b/src/components/gallery/Tags.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 const StyledTags = styled.div`
@@ -8,6 +8,7 @@ const StyledTags = styled.div`
   padding-top: 1rem;
   padding-bottom: 1rem;
   margin-bottom: -1.75rem;
+  cursor: pointer;
 
   & :not(:first-child) {
     margin-left: 0.5rem;
@@ -18,7 +19,7 @@ const StyledTags = styled.div`
   };
 `;
 
-const Tag = styled(Link)`
+const Tag = styled.span`
   flex-shrink: 0;
   height: 1.5rem;
   font-size: 0.75rem;
@@ -39,36 +40,26 @@ const Tag = styled(Link)`
   }
  `;
 
-function Tags({ postCount, tags }) {
-  const [selectedId, setSelectedId] = useState('');
+function Tags({ tags }) {
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const handleClick = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
 
-    const target = e.target.closest('a');
-    setSelectedId(target.id);
+    const id = e.target.dataset.id.split('tags-')[1];
+    if (id === 'all') {
+      searchParams.delete('tag');
+    } else {
+      searchParams.set('tag', id);
+    }
+    setSearchParams(searchParams);
   };
 
-  // TODO
-  // - [ ] 전체보기 카테고리 생기면 수정
   return (
     <StyledTags className="Tags" onClick={handleClick}>
-      <Tag key="allCategories" to="/gallery" id="allCategories" className="Tag selected">
-        전체보기
-        <span>
-          (
-          {postCount}
-          )
-        </span>
-      </Tag>
       {tags.map(({ _id, name, post }) => (
-        <Tag key={_id} id={_id} to={`/gallery?tag=${_id}`} className={`Tag ${_id === selectedId ? 'selected' : null}`}>
-          {name}
-          <span>
-            (
-            {post}
-            )
-          </span>
+        <Tag key={_id} data-id={`tags-${_id}`} className={_id === searchParams.get('tag') ? 'selected' : undefined}>
+          {`${name}(${post})`}
         </Tag>
       ))}
     </StyledTags>


### PR DESCRIPTION
+ detail 페이지나 슬라이더 썸네일의 태그 클릭시 사이드바 태그 하이라이팅
  + before: Tags와 TagList의 handleClick에서 하이라이팅 제어
  + after: SideBar의 handleSelected에서 searchParams를 이용해 하이라이팅 제어

+ handleSelected의 selected 토글 로직 수정
  + before: DOM에 직접 접근해서 토글
  + after: tags의 인터페이스를 selected 속성을 추가한 TagProps로 설정, setTags로 토글
---
### TODOs
- [x]  헤더의 전체보기를 통해 gallery 진입시 전체보기 태그가 하이라이팅 되지 않는 오류 수정 
- [x]  handleSelected의 selected 토글 로직 수정
